### PR TITLE
feat: add UUID and date format support for string types

### DIFF
--- a/src/generator/dto-generator.ts
+++ b/src/generator/dto-generator.ts
@@ -196,6 +196,18 @@ export class DtoGenerator {
       if (schema.format === 'email') {
         decorators.push('@IsEmail()');
       }
+      
+      if (schema.format === 'uuid') {
+        decorators.push('@IsUUID()');
+      } 
+      
+      if (schema.format === 'date') {
+        decorators.push('@IsDateString()');
+      }
+      
+      if (schema.format === 'date-time') {
+        decorators.push('@IsDateTimeString()');
+      } 
 
       if (schema.enum) {
         const enumName = this.getEnumName(name, schema.enum);

--- a/tests/fixtures/user.openapi.yaml
+++ b/tests/fixtures/user.openapi.yaml
@@ -279,6 +279,11 @@ components:
           example: "Doe"
           minLength: 1
           maxLength: 50
+        dateOfBirth:
+          type: string
+          format: date
+          description: User's date of birth
+          example: "2001-04-26"
         age:
           type: integer
           description: User's age

--- a/tests/generator/dto-generator.test.ts
+++ b/tests/generator/dto-generator.test.ts
@@ -39,6 +39,9 @@ describe('DtoGenerator', () => {
       // Email validation
       expect(result).toContain('@IsString()');
       expect(result).toContain('@IsEmail()');
+      expect(result).toContain('@IsUUID()');
+      expect(result).toContain('@IsDateString()');
+      expect(result).toContain('@IsDateTimeString()');
       
       // String length validation
       expect(result).toContain('@MinLength(1)');


### PR DESCRIPTION
- Add support for @IsUUID() decorator when format is 'uuid'
- Add support for @IsDateString() decorator when format is 'date' or 'date-time'
- Update string validation logic to use specific decorators based on format
- Add dateOfBirth field to test fixtures
- Update unit tests to validate new format handling