### PR TITLE
feat: decorator fix

### DIFF
--- a/src/templates/dto.hbs
+++ b/src/templates/dto.hbs
@@ -3,7 +3,8 @@ import {
   IsString, IsNumber, IsBoolean, IsArray, IsOptional, 
   IsEmail, IsEnum, IsUUID, IsDateString,
   Min, Max, MinLength, MaxLength, Matches,
-  ValidateNested, IsInt, IsDate, ArrayMaxSize, ArrayMinSize
+  ValidateNested, IsInt, IsDate, ArrayMaxSize, ArrayMinSize,
+  IsObject
 } from 'class-validator';
 import { Type } from 'class-transformer';
 

--- a/src/utils/template-loader.ts
+++ b/src/utils/template-loader.ts
@@ -121,7 +121,7 @@ export class {{className}}Service {
 import { 
   IsString, IsNumber, IsBoolean, IsArray, IsOptional, 
   IsEmail, IsEnum, Min, Max, MinLength, MaxLength, Matches,
-  ValidateNested, IsInt
+  ValidateNested, IsInt, IsObject
 } from 'class-validator';
 import { Type } from 'class-transformer';
 

--- a/tests/orchestrator/generator-orchestrator.test.ts
+++ b/tests/orchestrator/generator-orchestrator.test.ts
@@ -57,6 +57,7 @@ describe('GeneratorOrchestrator', () => {
       expect(dtoContent).toContain('import { ApiProperty } from \'@nestjs/swagger\'');
       expect(dtoContent).toContain('import {');
       expect(dtoContent).toContain('IsString, IsNumber, IsBoolean, IsArray, IsOptional');
+      expect(dtoContent).toContain('IsObject');
       expect(dtoContent).toContain('} from \'class-validator\'');
 
       // Check DTO classes


### PR DESCRIPTION
This pull request adds support for the `IsObject` decorator from `class-validator` across the DTO template generation and related utilities. The main changes ensure that DTOs can now validate object types using `IsObject`, and the corresponding imports and tests have been updated.

**Decorator import updates:**

* Added `IsObject` to the list of imported decorators in `src/templates/dto.hbs` to enable object validation in DTO templates.
* Added `IsObject` to the imports in `src/utils/template-loader.ts` to ensure the utility can handle object validation requirements.

**Test coverage:**

* Updated the test in `tests/orchestrator/generator-orchestrator.test.ts` to check for the presence of `IsObject` in generated DTO content, ensuring the decorator is included as expected.