### PR TITLE
fix: emit @IsObject() for $ref fields resolving to type: object schemas

### DIFF
--- a/src/generator/dto-generator.ts
+++ b/src/generator/dto-generator.ts
@@ -385,6 +385,10 @@ export class DtoGenerator {
                 }
             }
         } else if (schema.$ref) {
+            const resolvedSchema = this.resolveSchemaReference(schema.$ref, spec);
+            if (resolvedSchema?.type === 'object') {
+                decorators.push('@IsObject()');
+            }
             decorators.push('@ValidateNested()');
             const typeReference = type !== 'any' ? type : 'Object';
             decorators.push(`@Type(() => ${typeReference})`);


### PR DESCRIPTION
Without @IsObject(), class-validator's @ValidateNested() crashes with a 500 when the field is undefined, instead of returning a 400 validation error. The fix resolves the $ref target schema first and only emits @IsObject() when the resolved schema is type: object — so string enums and other $ref types are unaffected.

Verified against a NestJS + Fastify app: missing required nested object field now returns 400 VALIDATION_ERROR instead of 500 INTERNAL_ERROR.